### PR TITLE
Added WordPress.gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -8,4 +8,4 @@
 #
 # These files are text and should be normalized (Convert crlf => lf)
 *.gitattributes text
-*.gitignore text
+.gitignore text

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,4 +8,4 @@
 #
 # These files are text and should be normalized (Convert crlf => lf)
 *.gitattributes text
-
+*.gitignore text

--- a/WordPress.gitattributes
+++ b/WordPress.gitattributes
@@ -1,0 +1,43 @@
+# These settings are for WordPress.
+# However, any attribute that may generally be considered as appropriate for web, may also be added here.
+
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+
+# These files are text and should be normalized (Convert crlf => lf)
+*.php text
+*.css text
+*.js text
+*.htm text
+*.html text
+*.xml text
+*.txt text
+*.ini text
+*.inc text
+.htaccess text
+
+# These files are binary and should be left untouched
+# (binary is a macro for -text -diff)
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.mov binary
+*.mp4 binary
+*.mp3 binary
+*.flv binary
+*.fla binary
+*.swf binary
+*.gz binary
+*.zip binary
+*.7z binary
+*.ttf binary
+*.pdf binary
+*.doc binary
+*.docx binary


### PR DESCRIPTION
The main purpose of this pull request is to add the **WordPress.gitattributes** file. Please add it to your repository.

I've also made a small change to the project's main **.gitattributes** file (to specifically consider the **.gitignore** file as text). However, this change is not important for the main project. _" \* text=auto "_ should handle it automatically, but I like my settings clean. So you may or may not consider including this change, it's up to you.
