### PR TITLE
Add ear as binary

### DIFF
--- a/Java.gitattributes
+++ b/Java.gitattributes
@@ -27,6 +27,7 @@
 # (binary is a macro for -text -diff)
 *.class         binary
 *.dll           binary
+*.ear           binary
 *.gif           binary
 *.ico           binary
 *.jar           binary


### PR DESCRIPTION
Ear files are java enterprise archives usually containing war and/or jar files.
Details: http://en.wikipedia.org/wiki/EAR_%28file_format%29
