### PR TITLE
Create C++.gitattributes

### DIFF
--- a/C++.gitattributes
+++ b/C++.gitattributes
@@ -1,0 +1,36 @@
+#sources
+*.C text
+*.cc text
+*.cxx text
+*.cpp text
+*.c++ text
+*.hpp text
+*.h text
+*.h++ text
+*.hh text
+
+# Compiled Object files
+*.slo binary
+*.lo binary
+*.o binary
+*.obj binary
+
+# Precompiled Headers
+*.gch binary
+*.pch binary
+
+# Compiled Dynamic libraries
+*.so binary
+*.dylib binary
+*.dll binary
+
+# Compiled Static libraries
+*.lai binary
+*.la binary
+*.a binary
+*.lib binary
+
+# Executables
+*.exe binary
+*.out binary
+*.app binary


### PR DESCRIPTION
"*.out" is debatable, but keep in mind that most compilers creat binaries of "a.out" by default
