### PR TITLE
gitattributes recognizes pdfs as binary

### DIFF
--- a/Web.gitattributes
+++ b/Web.gitattributes
@@ -92,3 +92,4 @@ AUTHORS text
 *.7z binary
 *.ttf binary
 *.pyc binary
+*.pdf binary


### PR DESCRIPTION
Honestly, PDFs should not be in the repo.. but if they are 
put in there, they should not be fiddled with.
