### PR TITLE
Add more image extensions to Common.gitattributes

### DIFF
--- a/Common.gitattributes
+++ b/Common.gitattributes
@@ -33,5 +33,8 @@
 *.jpg binary
 *.jpeg binary
 *.gif binary
+*.tif binary
+*.tiff binary
 *.ico binary
 *.svg text
+*.eps binary


### PR DESCRIPTION
Add the following extensions and set them to binary:
*.tif and *.tiff for TIFF files
*.eps for EPS files
As a vector graphics format, EPS files are written in text, but are
not really human-parsable, unlike SVG files. For this reason, I have
set them to binary. They certainly do not want to have EOL correction
applied, so they need `-text`, and I don't think humans will typically
be interested in their diff, so `-diff`, hence `binary` will suffice.
