### PR TITLE
Remove inline comments

### DIFF
--- a/Matlab.gitattributes
+++ b/Matlab.gitattributes
@@ -4,22 +4,23 @@
 
 # Source files
 # ============
-*.m             text        # MATLAB source code
+*.m             text
+*.mu            text
+
 # Caution: *.m also matches Mathematica packages.
-*.mu            text        # MuPAD code
 
 # Binary files
 # ============
-*.p             binary      # obfuscated .m file
-*.mex*          binary      # compiled .m file
-*.fig           binary      # MATLAB figure
-*.mat           binary      # MATLAB variable dump
-*.mdl           binary      # simulink model
-*.slx           binary      # simulink model
-*.mdlp          binary      # obfuscated simulink model
-*.slxp          binary      # obfuscated simulink model
-*.sldd          binary      # simulink datadirectory
-*.mltbx         binary      # toolbox installer
-*.mlappinstall  binary      # app installer
-*.mlpkginstall  binary      # package installer
-*.mn            binary      # mupad notebook
+*.p             binary
+*.mex*          binary
+*.fig           binary
+*.mat           binary
+*.mdl           binary
+*.slx           binary
+*.mdlp          binary
+*.slxp          binary
+*.sldd          binary
+*.mltbx         binary
+*.mlappinstall  binary
+*.mlpkginstall  binary
+*.mn            binary


### PR DESCRIPTION
Git does not actually support inline comments within
.gitattributes and complains that # is not a valid attribute name.

Apologies for adding the file with inline comments originally. I don't know why I didn't notice this problem before.
