### PR TITLE
Change svg from text to binary in Common.gitattributes file

### DIFF
--- a/Common.gitattributes
+++ b/Common.gitattributes
@@ -36,5 +36,5 @@
 *.tif binary
 *.tiff binary
 *.ico binary
-*.svg text
+*.svg binary
 *.eps binary


### PR DESCRIPTION
Change the *.svg file pattern from 'text' type to 'binary' type in 'Common.gitattributes' file.
