### PR TITLE
Remove *.svg - duplicate of 'common', should be 'binary'

### DIFF
--- a/Java.gitattributes
+++ b/Java.gitattributes
@@ -17,7 +17,6 @@
 *.jspf          text
 *.properties    text
 *.sh            text
-*.svg           text
 *.tld           text
 *.txt           text
 *.xml           text


### PR DESCRIPTION
`*.svg` is declared in _Common.gitattributes_
Type are also different between _Java_ vs. _Common_.
