### PR TITLE
Remove .ts as binary file to allow TypeScript text

### DIFF
--- a/Web.gitattributes
+++ b/Web.gitattributes
@@ -151,7 +151,6 @@ Procfile       text
 *.mpg  binary
 *.swc  binary
 *.swf  binary
-*.ts   binary
 *.webm binary
 
 ## ARCHIVES


### PR DESCRIPTION
Currently the `Web.gitattributes` file cannot be used within TypeScript projects, as there are two conflicting entries for `*.ts` files.

This PR removes the `*.ts binary` rule under the 'Video' section. The existing `*.ts text` rule remains, as it should.
