### PR TITLE
batch files ought to always have crlf endings

### DIFF
--- a/Web.gitattributes
+++ b/Web.gitattributes
@@ -15,7 +15,7 @@
 * text=auto
 
 ## SOURCE CODE
-*.bat    text
+*.bat    text eol=crlf
 *.coffee text
 *.css    text
 *.htm    text


### PR DESCRIPTION
This makes it easier to work with such files on systems where the native lineending isn't CRLF