### PR TITLE
Added Nunjucks Template to Web.gitattributes

### DIFF
--- a/Web.gitattributes
+++ b/Web.gitattributes
@@ -77,6 +77,7 @@ TODO         text
 *.mustache   text
 *.phtml      text
 *.tmpl       text
+*.njk        text
 
 ## LINTERS
 .csslintrc    text


### PR DESCRIPTION
[Nunjucks](https://mozilla.github.io/nunjucks/) is a template engine created by Mozilla. It uses `.njk` as its file extension, please see: https://mozilla.github.io/nunjucks/templating.html#file-extensions