### PR TITLE
Add .tsx Extension

### DIFF
--- a/Web.gitattributes
+++ b/Web.gitattributes
@@ -40,6 +40,7 @@
 *.sql      text
 *.styl     text
 *.ts       text
+*.tsx      text
 *.xml      text
 *.xhtml    text
 


### PR DESCRIPTION
When writing React apps with TypeScript the `.tsx` extension can be used.