### PR TITLE
.gitignore is better left alone

### DIFF
--- a/Web.gitattributes
+++ b/Web.gitattributes
@@ -108,7 +108,6 @@ TODO         text
 .editorconfig  text
 .gitattributes text
 .gitconfig     text
-.gitignore     text
 .htaccess      text
 *.npmignore    text
 *.yaml         text


### PR DESCRIPTION
If you try the following steps,  you can quickly reproduce an issue where `.gitignore` will be modified by `git` unjustifiably (without even being able to easily discarding its modified status):

```bash
mkdir try_giteol
cd try_giteol/
git init
git commit --allow-empty -m'First commit.'
curl -fsSL "https://raw.githubusercontent.com/github/gitignore/master/Global/macOS.gitignore" > .gitignore
curl -fsSL "https://raw.githubusercontent.com/alexkaratarakis/gitattributes/master/Web.gitattributes" > .gitattributes
git add .
git commit -m'Adds git attributes and ignores'
git branch foo
git reset --hard HEAD^
git reset --hard foo
```

The reason, I believe, is being `.gitignore text` will “cancel” the `\r\r` (yes, those are double `\r`s (hidden chars, of course) in line that contains `Icon\r\r\n` and will convert `\r\r\n` into `\r\n`.

To the question “why those pesky” double `\r\r` are necessary, you could read more at https://github.com/github/gitignore/pull/2337.

Cheers 🍷 