### PR TITLE
Apply sentence case to comment in line 1

### DIFF
--- a/Common.gitattributes
+++ b/Common.gitattributes
@@ -1,4 +1,4 @@
-#common settings that generally should always be used with your language specific settings
+# Common settings that generally should always be used with your language specific settings
 
 # Auto detect text files and perform LF normalization
 # http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/


### PR DESCRIPTION
Apply sentence case to the comment in line 1 of Common.gitattributes

Changed: `#common settings that generally should always be used with your language specific settings`

To: `# Common settings that generally should always be used with your language specific settings`