### PR TITLE
Added *.ipynb extension in Web.gitattributes list

### DIFF
--- a/Web.gitattributes
+++ b/Web.gitattributes
@@ -50,6 +50,7 @@
 Dockerfile    text
 
 ## DOCUMENTATION
+*.ipynb      text
 *.markdown   text
 *.md         text
 *.mdwn       text


### PR DESCRIPTION
I chose to insert the extension in the list of the Web.gitattributes because according to the [IPython documentation](https://ipython.org/ipython-doc/1/interactive/notebook.html):

> ### Notebook documents
>Notebook documents contains the inputs and outputs of a interactive session as well as additional text that accompanies the code but is not meant for execution. In this way, notebook files can serve as a complete computational record of a session, interleaving executable code with explanatory text, mathematics, and rich representations of resulting objects. These documents are internally JSON files and are saved with the .ipynb extension. Since JSON is a plain text format, they can be version-controlled and shared with colleagues.

Anyway I may be incorrect. I hope it's useful.