### PR TITLE
Exclude git files from zip export

### DIFF
--- a/Common.gitattributes
+++ b/Common.gitattributes
@@ -41,3 +41,10 @@
 *.svg binary
 #*.svg text
 *.eps binary
+
+#
+# Exclude files from exporting
+#
+
+.gitattributes export-ignore
+.gitignore export-ignore


### PR DESCRIPTION
With this extra code, when a user clicks the "Download ZIP" button on a repository the `.gitignore` and `.gitattributes` files won't be included in the zip.