### PR TITLE
Add Go Gitattributes file (Closes #82)

### DIFF
--- a/Go.gitattributes
+++ b/Go.gitattributes
@@ -1,0 +1,10 @@
+# Treat all files in this repo as binary, with no git magic updating
+# line endings. Windows users contributing to Go will need to use a
+# modern version of git and editors capable of LF line endings.
+#
+# We'll prevent accidental CRLF line endings from entering the repo
+# via the git-review gofmt checks.
+#
+# See golang.org/issue/9281
+
+* -text

--- a/Go.gitattributes
+++ b/Go.gitattributes
@@ -1,10 +1,5 @@
-# Treat all files in this repo as binary, with no git magic updating
+# Treat all Go files in this repo as binary, with no git magic updating
 # line endings. Windows users contributing to Go will need to use a
 # modern version of git and editors capable of LF line endings.
-#
-# We'll prevent accidental CRLF line endings from entering the repo
-# via the git-review gofmt checks.
-#
-# See golang.org/issue/9281
 
-* -text
+*.go -text


### PR DESCRIPTION
This Pull Request adds a `Go.gitattributes` file that can be used in Golang Projects.
After merging, issue #82 should automatically close.