### PR TITLE
Add CSS diff support

### DIFF
--- a/Ballerina.gitattributes
+++ b/Ballerina.gitattributes
@@ -7,7 +7,7 @@
 #
 # These files are text and should be normalized (Convert crlf => lf)
 *.bal           text
-*.css           text
+*.css           text diff=css
 *.df            text
 *.htm           text
 *.html          text
@@ -33,4 +33,3 @@
 *.jpeg          binary
 *.png           binary
 *.so            binary
-

--- a/Drupal.gitattributes
+++ b/Drupal.gitattributes
@@ -19,7 +19,7 @@
 # Auto-detect text files, ensure they use LF.
 * text=auto eol=lf
 
-*.css     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
+*.css     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=css
 *.engine  text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php
 *.html    text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=html
 *.inc     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php

--- a/Java.gitattributes
+++ b/Java.gitattributes
@@ -6,7 +6,7 @@
 # The above will handle all files NOT found below
 #
 # These files are text and should be normalized (Convert crlf => lf)
-*.css           text
+*.css           text diff=css
 *.df            text
 *.htm           text
 *.html          text
@@ -38,4 +38,3 @@
 *.png           binary
 *.so            binary
 *.war           binary
-

--- a/Lua.gitattributes
+++ b/Lua.gitattributes
@@ -7,4 +7,4 @@
 # Luadoc output
 # =============
 *.html      text
-*.css       text
+*.css       text diff=css

--- a/Servoy.gitattributes
+++ b/Servoy.gitattributes
@@ -7,5 +7,5 @@
 *.obj -text
 *.dbi -text
 *.sec -text
-*.css -text
+*.css -text diff=css
 *.js eol=lf


### PR DESCRIPTION
This PR adds proper CSS Diff support for the following files:
- `Ballerina.gitattributes`
- `Drupal.gitattributes`
- `Java.gitattributes`
- `Lua.gitattributes`
- `Servoy.gitattributes`

You know, it would be much easier to collaborate on this project if you made me a collaborator...