### PR TITLE
docs: Add link to Github specific grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Please contribute by [forking][fk] and sending a [pull request][pr].
 Also **please** only modify **one file** per commit. This'll
 make merging easier for everyone.
 
-For more information on gitattributes: [gitattributes(5)][g5]
-For more information on Github + gitattributes: [github help][gh]
+For more information on gitattributes: [gitattributes(5)][g5] and for Github-specific grammar: [Linguist docs][gh]
 
 [gt]: https://github.com/github/gitignore
 [fk]: http://help.github.com/forking/

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ Also **please** only modify **one file** per commit. This'll
 make merging easier for everyone.
 
 For more information on gitattributes: [gitattributes(5)][g5]
+For more information on Github + gitattributes: [github help][gh]
 
 [gt]: https://github.com/github/gitignore
 [fk]: http://help.github.com/forking/
 [pr]: http://help.github.com/pull-requests/
 [g5]: http://schacon.github.com/git/gitattributes.html
+[gh]: https://www.rubydoc.info/github/github/linguist


### PR DESCRIPTION
There are several specific Github attributes to control how you changes and source code are presented.
For example, one can use `linguist-generated` or `linguist-vendored` and  to discard some files from language index.

Examples:
- https://github.com/wemake-services/wemake-django-template/blob/master/.gitattributes
- https://help.github.com/en/articles/customizing-how-changed-files-appear-on-github