### PR TITLE
Add .fish scripts support to Common.gitattributes

### DIFF
--- a/Common.gitattributes
+++ b/Common.gitattributes
@@ -48,6 +48,7 @@
 
 # Scripts
 *.bash     text eol=lf
+*.fish     text eol=lf
 *.sh       text eol=lf
 # These are explicitly windows files and should use crlf
 *.bat      text eol=crlf


### PR DESCRIPTION
".fish" is the extension for [fish shell](https://fishshell.com), which is increasingly common nowadays