### PR TITLE
fix: Deleted doubled file types with wrong category

### DIFF
--- a/Python.gitattributes
+++ b/Python.gitattributes
@@ -5,9 +5,6 @@
 *.pxd    text diff=python
 *.py     text diff=python
 *.py3    text diff=python
-*.pyc    text diff=python
-*.pyd    text diff=python
-*.pyo    text diff=python
 *.pyw    text diff=python
 *.pyx    text diff=python
 *.pyz    text diff=python


### PR DESCRIPTION
The file types `*.pyc` , `*.pyd` and `*.pyo` are doubled. 
1. In the "Source files" part defined as `text`
2. In the "Binary files" part defined as `binary`

I have deleted the ones with the `text` category.