### PR TITLE
Preserve line endings in patch files

### DIFF
--- a/Common.gitattributes
+++ b/Common.gitattributes
@@ -68,6 +68,9 @@
 *.tar      binary
 *.zip      binary
 
+# Text files where line endings should be preserved
+*.patch    -text
+
 #
 # Exclude files from exporting
 #


### PR DESCRIPTION
I believe this is the correct attribute for patch files, where line endings can be mixed – the patch statements use LF, but the patch contents can be CRLF or LF