### PR TITLE
Fix syntax highlighting of `*.gitattributes` files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,8 @@
 
 .gitattributes  export-ignore
 .gitignore      export-ignore
+
+#
+# Enable syntax highlighting for files with `.gitattributes` extensions.
+#
+*.gitattributes linguist-language=gitattributes


### PR DESCRIPTION
Linguist only [recognises](https://github.com/github/linguist/blob/ccb71a915a8be343466a176b1309040c9541795c/lib/linguist/languages.yml#L1736-L1742) files named `.gitattributes`, not those named `Common.gitattributes`, etc. For this reason, most of the files in this repository aren't being highlighted. This PR fixes that.

Note that changes to `.gitattributes` files won't take effect on GitHub until something else has been modified in a follow-up commit (it's an acknowledged caching issue). So you may not see any changes right after merging this pull-request.