### PR TITLE
Add .sh and .txt rules for common gitattributes

### DIFF
--- a/Common.gitattributes
+++ b/Common.gitattributes
@@ -27,6 +27,8 @@
 *.tab text
 *.tsv text
 *.sql text
+*.txt text
+*.sh text eol=lf
 
 # Graphics
 *.png binary


### PR DESCRIPTION
Especially important are .sh rules, because during checking out on Windows machine they got Windows end of line, which causes problems when scripts are copied to Docker image.