### PR TITLE
Add python stubs files (.pyi)

### DIFF
--- a/Python.gitattributes
+++ b/Python.gitattributes
@@ -8,6 +8,7 @@
 *.pyw    text diff=python
 *.pyx    text diff=python
 *.pyz    text diff=python
+*.pyi    text diff=python
 
 # Binary files
 # ============


### PR DESCRIPTION
Python stubs (`.pyi`) files are used to write type hints that are only for use by the type checker, not at runtime.

[PEP 484 - "Stub files" section](https://www.python.org/dev/peps/pep-0484/#stub-files)
[`mypy` about stub files](https://mypy.readthedocs.io/en/stable/stubs.html)

