### PR TITLE
Add jks extension as a binary

### DIFF
--- a/Java.gitattributes
+++ b/Java.gitattributes
@@ -26,3 +26,4 @@
 *.jar           binary
 *.so            binary
 *.war           binary
+*.jks           binary


### PR DESCRIPTION
Since a keystore is also a binary and it might be added to a repository, probably good add it to the Java list too