### PR TITLE
Added Vim

### DIFF
--- a/Vim.gitattributes
+++ b/Vim.gitattributes
@@ -4,3 +4,5 @@
 # Source files
 # ============
 *.vim text eol=lf
+.vimrc text eol=lf
+.gvimrc text eol=lf

--- a/Vim.gitattributes
+++ b/Vim.gitattributes
@@ -1,0 +1,6 @@
+# Basic .gitattributes for a Vim repo.
+# Vim on Linux works with LF only, Vim on Windows works with both LF and CRLF
+
+# Source files
+# ============
+*.vim text eol=lf


### PR DESCRIPTION
Like the comment says, Vim on Windows seems to work fine with both LF and CRLF line endings, however on Linux systems when sourcing scripts with CRLF line endings, you get errors like the following:

```
E15: Invalid expression: 1^M
E492: Not an editor command: ^M
```