### PR TITLE
Remove crlf for ps1 as it is cross-platform

### DIFF
--- a/Common.gitattributes
+++ b/Common.gitattributes
@@ -30,6 +30,8 @@
 *.tsv      text
 *.txt      text
 *.sql      text
+# PowerShell core is cross-platform and so it should not be forced to use crlf
+*.ps1      text
 
 # Graphics
 *.png      binary
@@ -53,7 +55,6 @@
 # These are explicitly windows files and should use crlf
 *.bat      text eol=crlf
 *.cmd      text eol=crlf
-*.ps1      text eol=crlf
 
 # Serialisation
 *.json     text

--- a/Common.gitattributes
+++ b/Common.gitattributes
@@ -30,7 +30,6 @@
 *.tsv      text
 *.txt      text
 *.sql      text
-# PowerShell core is cross-platform and so it should not be forced to use crlf
 *.ps1      text
 
 # Graphics


### PR DESCRIPTION
Powershell Core (Version 6 and above) retains the ps1 file extension but is cross-platform, running on Windows, Linux and Mac OS https://github.com/PowerShell/PowerShell
It should not be forced to use crlf