### PR TITLE
Remove crlf for ps1 as it is cross-platform

### DIFF
--- a/Web.gitattributes
+++ b/Web.gitattributes
@@ -35,7 +35,7 @@
 *.onlydata        text
 *.php             text diff=php
 *.pl              text
-*.ps1             text eol=crlf
+*.ps1             text
 *.py              text diff=python
 *.rb              text diff=ruby
 *.sass            text


### PR DESCRIPTION
Powershell Core (Version 6 and above) retains the ps1 file extension but is cross-platform, running on Windows, Linux and Mac OS https://github.com/PowerShell/PowerShell
It should not be forced to use crlf