### PR TITLE
Add CRLF EOL for Window-specific file formats and add diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,7 +9,7 @@
 # These files are text and should be normalized (Convert crlf => lf)
 *.gitattributes text
 .gitignore      text
-*.md            text
+*.md            text diff=markdown
 
 #
 # Exclude files from exporting

--- a/Common.gitattributes
+++ b/Common.gitattributes
@@ -20,7 +20,7 @@
 *.PDF      diff=astextplain
 *.rtf      diff=astextplain
 *.RTF      diff=astextplain
-*.md       text
+*.md       text diff=markdown
 *.tex      text diff=tex
 *.adoc     text
 *.textile  text
@@ -30,7 +30,7 @@
 *.tsv      text
 *.txt      text
 *.sql      text
-*.ps1      text
+*.ps1      text eol=crlf
 
 # Graphics
 *.png      binary

--- a/Web.gitattributes
+++ b/Web.gitattributes
@@ -20,7 +20,7 @@
 *.bat             text eol=crlf
 *.cmd             text eol=crlf
 *.coffee          text
-*.css             text
+*.css             text diff=css
 *.htm             text diff=html
 *.html            text diff=html
 *.inc             text
@@ -35,7 +35,7 @@
 *.onlydata        text
 *.php             text diff=php
 *.pl              text
-*.ps1             text
+*.ps1             text eol=crlf
 *.py              text diff=python
 *.rb              text diff=ruby
 *.sass            text
@@ -55,12 +55,12 @@ Dockerfile        text
 
 # Documentation
 *.ipynb           text
-*.markdown        text
-*.md              text
-*.mdwn            text
-*.mdown           text
-*.mkd             text
-*.mkdn            text
+*.markdown        text diff=markdown
+*.md              text diff=markdown
+*.mdwn            text diff=markdown
+*.mdown           text diff=markdown
+*.mkd             text diff=markdown
+*.mkdn            text diff=markdown
 *.mdtxt           text
 *.mdtext          text
 *.txt             text
@@ -106,7 +106,10 @@ TODO              text
 .gitconfig        text
 .htaccess         text
 *.lock            text -diff
-package-lock.json text -diff
+package.json      text eol=lf
+package-lock.json text eol=lf -diff
+pnpm-lock.yaml    text eol=lf -diff
+yarn.lock         text -diff
 *.toml            text
 *.yaml            text
 *.yml             text


### PR DESCRIPTION
Note on package.json:
- npm detects what line endings are used https://github.com/npm/npm/pull/19904
- yarn uses the os line endings https://github.com/yarnpkg/yarn/pull/1911
- pnpm currently (v5.18.11 as of this writing) enforces lf

Therefore, the line specifying package.json to use `eol=lf` is for pnpm and not needed for npm and yarn.
