### PR TITLE
DOC: Fix comment about default SVG behaviour (text not binary)

### DIFF
--- a/Common.gitattributes
+++ b/Common.gitattributes
@@ -40,7 +40,7 @@
 *.tif      binary
 *.tiff     binary
 *.ico      binary
-# SVG treated as an asset (binary) by default.
+# SVG treated as text by default.
 *.svg      text
 # If you want to treat it as binary,
 # use the following line instead.


### PR DESCRIPTION
The default setting for svg files was previously changed from binary to text, but the comment about it was not.

This PR has no functional change, but adjusts the comment to match what is going on.