### PR TITLE
ENH: Add export-ignore to compiled python files

### DIFF
--- a/Python.gitattributes
+++ b/Python.gitattributes
@@ -16,9 +16,9 @@
 *.p      binary
 *.pkl    binary
 *.pickle binary
-*.pyc    binary
+*.pyc    binary export-ignore
+*.pyo    binary export-ignore
 *.pyd    binary
-*.pyo    binary
 
 # Jupyter notebook
 *.ipynb  text


### PR DESCRIPTION
Since Python uses just-in-time compilation, the compiled binaries (.pyc and .pyo files) are not something you would want to include in an archive of a python code base. Hence we add an export-ignore attribute to these file extensions.

I also re-ordered the extensions because a .pyo file is just a .pyc file with optimization enabled, so it makes sense to have these next to each other without .pyd in between.