### PR TITLE
Add Kotlin, Groovy, Scala and Sass to Java

### DIFF
--- a/Java.gitattributes
+++ b/Java.gitattributes
@@ -1,10 +1,15 @@
 # Java sources
 *.java          text diff=java
+*.kt            text diff=java
+*.groovy        text diff=java
+*.scala         text diff=java
 *.gradle        text diff=java
 *.gradle.kts    text diff=java
 
 # These files are text and should be normalized (Convert crlf => lf)
 *.css           text diff=css
+*.scss          text diff=css
+*.sass          text
 *.df            text
 *.htm           text diff=html
 *.html          text diff=html


### PR DESCRIPTION
Thanks for providing these great lists!

I would like to add support for Kotlin, Groovy and Scala, and thought they should probably go into the Java file instead of having their own ones.

Also, since the Java file contains css, it should probably also contain scss and sass.