### PR TITLE
Update C++.gitattributes: Use "cpp" instead of "c" diff pattern

### DIFF
--- a/C++.gitattributes
+++ b/C++.gitattributes
@@ -1,11 +1,11 @@
 # Sources
-*.c     text diff=c
+*.c     text diff=cpp
 *.cc    text diff=cpp
 *.cxx   text diff=cpp
 *.cpp   text diff=cpp
 *.c++   text diff=cpp
 *.hpp   text diff=cpp
-*.h     text diff=c
+*.h     text diff=cpp
 *.h++   text diff=cpp
 *.hh    text diff=cpp
 


### PR DESCRIPTION
The official documentation does not say anything about a "c" diff pattern.
But it says that "cpp" is suitable for C and C++, so "cpp" should be fine.