### PR TITLE
Add embedded ruby template

### DIFF
--- a/Web.gitattributes
+++ b/Web.gitattributes
@@ -82,6 +82,7 @@ TODO              text
 # Templates
 *.dot             text
 *.ejs             text
+*.erb             text
 *.haml            text
 *.handlebars      text
 *.hbs             text


### PR DESCRIPTION
I added the *.erb file type, which was missing.

> ERB (Embedded RuBy) is a feature of Ruby that enables you to conveniently generate any kind of text, in any quantity, from templates.

> A file that contains an ERB template may have any name, but it is the convention that the name of file should end with the .erb extension.