### PR TITLE
Correct the setting for R Markdown files

### DIFF
--- a/R.gitattributes
+++ b/R.gitattributes
@@ -12,4 +12,4 @@
 *.Rmd	  text
 *.R  	  text
 *.Rproj text
-*.Rmd   linguist-language=R
+*.[Rr]md   linguist-detectable


### PR DESCRIPTION
Thanks for this very nice repo.

This fixes the setting for R Markdown files.

RMarkdown is in fact defined as a language in the Linguist languages.yml [here](https://github.com/github/linguist/blob/e2f638d17598e84f6f91c2d03c2f3e27f22a2163/lib/linguist/languages.yml#L4883), so all you need to do to make it show up in the Languages pane statistics is make it detectable because it currently gets ignored because it's a type of markdown.
