### PR TITLE
Add .husky/*

### DIFF
--- a/Web.gitattributes
+++ b/Web.gitattributes
@@ -42,6 +42,7 @@
 *.scm             text
 *.scss            text diff=css
 *.sh              text eol=lf
+.husky/*          text eol=lf
 *.sql             text
 *.styl            text
 *.tag             text


### PR DESCRIPTION
Personally I would change _everything_ to LF, I like the simplicity

I get that some windows-specific files can be crlf, like .bat files,
but I'm not sure why most files are not just defaulted to LF