### PR TITLE
Add epub to Common

### DIFF
--- a/Common.gitattributes
+++ b/Common.gitattributes
@@ -30,6 +30,7 @@
 *.tsv      text
 *.txt      text
 *.sql      text
+*.epub filter=lfs diff=lfs merge=lfs -text
 
 # Graphics
 *.png      binary

--- a/Common.gitattributes
+++ b/Common.gitattributes
@@ -30,7 +30,7 @@
 *.tsv      text
 *.txt      text
 *.sql      text
-*.epub filter=lfs diff=lfs merge=lfs -text
+*.epub     diff=astextplain
 
 # Graphics
 *.png      binary


### PR DESCRIPTION
Just like PDFs some of the epub files tend to be very large exceeding the maximum allowed file size on GitHub (100MB). This PR includes epub on the common Documents section to address this issue.