### PR TITLE
Jupyter notebooks are always created with LF (on Windows)

### DIFF
--- a/Python.gitattributes
+++ b/Python.gitattributes
@@ -21,7 +21,7 @@
 *.pyd    binary
 
 # Jupyter notebook
-*.ipynb  text
+*.ipynb  text eol=lf
 
 # Note: .db, .p, and .pkl files are associated
 # with the python modules ``pickle``, ``dbm.*``,

--- a/Web.gitattributes
+++ b/Web.gitattributes
@@ -55,7 +55,7 @@
 Dockerfile        text
 
 # Documentation
-*.ipynb           text
+*.ipynb           text eol=lf
 *.markdown        text diff=markdown
 *.md              text diff=markdown
 *.mdwn            text diff=markdown


### PR DESCRIPTION
When saving a notebook in Jupyter on Windows it is always saved with LF's as line endings (and not with CRLF's). This PR prevents unneeded commits when Jupyter changes the CRLF's back into LF's (while the notbook itself is not actually modified).