### PR TITLE
Add Config for Maven-/Gradle-Wrapper-Scripts

### DIFF
--- a/Java.gitattributes
+++ b/Java.gitattributes
@@ -32,3 +32,7 @@
 *.so            binary
 *.war           binary
 *.jks           binary
+
+# Common build-tool wrapper scripts ('.cmd' versions are handled by 'Common.gitattributes')
+mvnw            text eol=lf
+gradlew         text eol=lf


### PR DESCRIPTION
Maven and Gradle provide quite common wrapper scripts to use them without explicitly installing them before.
This is done by `mvnw` and `gradlew` shell scripts, without an explicit `.sh` extension.
The Windows versions of the scripts to contain the `.cmd` extension, so there is no need to handle them explicitly.

See the [Gradle Wrapper Docs](https://docs.gradle.org/current/userguide/gradle_wrapper.html) and [Maven Wrapper Docs ](https://maven.apache.org/wrapper/) for more information.