### PR TITLE
Create VisualStudioCode.gitattributes

### DIFF
--- a/VisualStudioCode.gitattributes
+++ b/VisualStudioCode.gitattributes
@@ -1,0 +1,2 @@
+# Fixes syntax highlighting on GitHub to allow comments
+.vscode/*.json linguist-language=JSON-with-Comments

--- a/VisualStudioCode.gitattributes
+++ b/VisualStudioCode.gitattributes
@@ -1,2 +1,2 @@
-# Fixes syntax highlighting on GitHub to allow comments
+# Fix syntax highlighting on GitHub to allow comments
 .vscode/*.json linguist-language=JSON-with-Comments


### PR DESCRIPTION
Why this would be a good idea:
- Fixes JSON vs JSON-with-comments syntax highlighting on GitHub
- Aligns with there being a VisualStudio.gitattributes file
- Makes a .gitattributes file for a very popular IDE/editor

Existing precedent from VisualStudio.gitattributes file:
https://github.com/alexkaratarakis/gitattributes/blob/master/VisualStudio.gitattributes

cc @spenserblack from https://github.com/spenserblack/.gitattributes