### PR TITLE
Remove "*.thing text" from Web.gitattributes

### DIFF
--- a/Web.gitattributes
+++ b/Web.gitattributes
@@ -19,40 +19,18 @@
 *.bash            text eol=lf
 *.bat             text eol=crlf
 *.cmd             text eol=crlf
-*.coffee          text
 *.css             text diff=css
 *.htm             text diff=html
 *.html            text diff=html
-*.inc             text
-*.ini             text
-*.js              text
-*.json            text
-*.jsx             text
-*.less            text
-*.ls              text
 *.map             text -diff
-*.od              text
-*.onlydata        text
 *.php             text diff=php
-*.pl              text
 *.ps1             text eol=crlf
 *.py              text diff=python
 *.rb              text diff=ruby
-*.sass            text
-*.scm             text
 *.scss            text diff=css
 *.sh              text eol=lf
 .husky/*          text eol=lf
-*.sql             text
-*.styl            text
-*.tag             text
-*.ts              text
-*.tsx             text
-*.xml             text
 *.xhtml           text diff=html
-
-# Docker
-Dockerfile        text
 
 # Documentation
 *.ipynb           text eol=lf
@@ -62,67 +40,13 @@ Dockerfile        text
 *.mdown           text diff=markdown
 *.mkd             text diff=markdown
 *.mkdn            text diff=markdown
-*.mdtxt           text
-*.mdtext          text
-*.txt             text
-AUTHORS           text
-CHANGELOG         text
-CHANGES           text
-CONTRIBUTING      text
-COPYING           text
-copyright         text
-*COPYRIGHT*       text
-INSTALL           text
-license           text
-LICENSE           text
-NEWS              text
-readme            text
-*README*          text
-TODO              text
-
-# Templates
-*.dot             text
-*.ejs             text
-*.erb             text
-*.haml            text
-*.handlebars      text
-*.hbs             text
-*.hbt             text
-*.jade            text
-*.latte           text
-*.mustache        text
-*.njk             text
-*.phtml           text
-*.svelte          text
-*.tmpl            text
-*.tpl             text
-*.twig            text
-*.vue             text
 
 # Configs
-*.cnf             text
-*.conf            text
-*.config          text
-.editorconfig     text
-.env              text
-.gitattributes    text
-.gitconfig        text
-.htaccess         text
 *.lock            text -diff
 package.json      text eol=lf
 package-lock.json text eol=lf -diff
 pnpm-lock.yaml    text eol=lf -diff
-.prettierrc       text
 yarn.lock         text -diff
-*.toml            text
-*.yaml            text
-*.yml             text
-browserslist      text
-Makefile          text
-makefile          text
-
-# Heroku
-Procfile          text
 
 # Graphics
 *.ai              binary
@@ -199,9 +123,3 @@ Procfile          text
 # Executables
 *.exe             binary
 *.pyc             binary
-
-# RC files (like .babelrc or .eslintrc)
-*.*rc             text
-
-# Ignore files (like .npmignore or .gitignore)
-*.*ignore         text


### PR DESCRIPTION
This PR just removes all the stuff that does redundant `*.thing text`. At least, I assume it's redundant? Looking for feedback on what's _actually needed_ in a .gitattributes file and what's just there by default.

idea from #184 about "trim all the redundant stuff"