### PR TITLE
Update Unity gitattributes

### DIFF
--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -2,6 +2,9 @@
 [attr]lfs           filter=lfs diff=lfs merge=lfs -text
 [attr]unity-yaml    merge=unityyamlmerge text linguist-language=yaml
 
+# Optionally collapse Unity-generated files on GitHub diffs
+# [attr]unity-yaml    merge=unityyamlmerge text linguist-language=yaml linguist-generated
+
 # Unity
 *.cginc             text
 *.cs                text diff=csharp
@@ -115,13 +118,6 @@
 *.a                 binary
 *.reason            binary
 *.rns               binary
-
-# Collapse Unity-generated files on GitHub
-*.asset             linguist-generated
-*.mat               linguist-generated
-*.meta              linguist-generated
-*.prefab            linguist-generated
-*.unity             linguist-generated
 
 # Spine export file for Unity
 *.skel.bytes        binary

--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -18,8 +18,6 @@
 
 # "physic" for 3D but "physics" for 2D
 *.physicMaterial    unity-yaml
-*.physicMaterial2D  unity-yaml
-*.physicsMaterial   unity-yaml
 *.physicsMaterial2D unity-yaml
 
 # Using Git LFS

--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -38,6 +38,7 @@
 *.overrideController    unity-yaml
 *.playable              unity-yaml
 *.prefab                unity-yaml
+*.preset                unity-yaml
 *.renderTexture         unity-yaml
 *.scenetemplate         unity-yaml
 *.shadervariants        unity-yaml

--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -1,6 +1,6 @@
 # Define macros
 [attr]lfs           filter=lfs diff=lfs merge=lfs -text
-[attr]unity-yaml    merge=unityyamlmerge text
+[attr]unity-yaml    merge=unityyamlmerge text linguist-language=yaml
 
 # Unity
 *.cginc             text

--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -1,25 +1,29 @@
+# Define macros
+[attr]unity-yaml    merge=unityyamlmerge text
+[attr]lfs           filter=lfs diff=lfs merge=lfs -text
+
 # Unity
 *.cginc              text
 *.cs                 text diff=csharp
 *.shader             text
 
 # Unity YAML
-*.mat                merge=unityyamlmerge eol=lf
-*.anim               merge=unityyamlmerge eol=lf
-*.unity              merge=unityyamlmerge eol=lf
-*.prefab             merge=unityyamlmerge eol=lf
-*.asset              merge=unityyamlmerge eol=lf
-*.meta               merge=unityyamlmerge eol=lf
-*.controller         merge=unityyamlmerge eol=lf
+*.mat                unity-yaml
+*.anim               unity-yaml
+*.unity              unity-yaml
+*.prefab             unity-yaml
+*.asset              unity-yaml
+*.meta               unity-yaml
+*.controller         unity-yaml
 
 # "physic" for 3D but "physics" for 2D
-*.physicMaterial2D   merge=unityyamlmerge eol=lf
-*.physicMaterial     merge=unityyamlmerge eol=lf
-*.physicsMaterial2D  merge=unityyamlmerge eol=lf
-*.physicsMaterial    merge=unityyamlmerge eol=lf
+*.physicMaterial2D   unity-yaml
+*.physicMaterial     unity-yaml
+*.physicsMaterial2D  unity-yaml
+*.physicsMaterial    unity-yaml
 
 # Using Git LFS
-# Add diff=lfs merge=lfs to the binary files
+# Replace 'binary' with 'lfs' on large files you wish to track with LFS
 
 # Unity LFS
 *.cubemap            binary

--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -19,7 +19,7 @@
 *.shadersubgraph        text linguist-language=json
 *.tss                   text diff=css linguist-language=css
 *.uss                   text diff=css linguist-language=css
-*.uxml                  text linguist-language=xml
+*.uxml                  text linguist-language=xml linguist-detectable
 
 # Unity YAML
 *.anim                  unity-yaml

--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -1,6 +1,6 @@
 # Define macros
-[attr]unity-yaml    merge=unityyamlmerge text
 [attr]lfs           filter=lfs diff=lfs merge=lfs -text
+[attr]unity-yaml    merge=unityyamlmerge text
 
 # Unity
 *.cginc             text
@@ -8,19 +8,19 @@
 *.shader            text
 
 # Unity YAML
-*.mat               unity-yaml
 *.anim              unity-yaml
-*.unity             unity-yaml
-*.prefab            unity-yaml
 *.asset             unity-yaml
-*.meta              unity-yaml
 *.controller        unity-yaml
+*.mat               unity-yaml
+*.meta              unity-yaml
+*.prefab            unity-yaml
+*.unity             unity-yaml
 
 # "physic" for 3D but "physics" for 2D
-*.physicMaterial2D  unity-yaml
 *.physicMaterial    unity-yaml
-*.physicsMaterial2D unity-yaml
+*.physicMaterial2D  unity-yaml
 *.physicsMaterial   unity-yaml
+*.physicsMaterial2D unity-yaml
 
 # Using Git LFS
 # Replace 'binary' with 'lfs' on large files you wish to track with LFS
@@ -115,8 +115,8 @@
 
 # ETC
 *.a                 binary
-*.rns               binary
 *.reason            binary
+*.rns               binary
 
 # Collapse Unity-generated files on GitHub
 *.asset             linguist-generated

--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -29,6 +29,7 @@
 *.fontsettings          unity-yaml
 *.giparams              unity-yaml
 *.guiskin               unity-yaml
+*.lighting              unity-yaml
 *.mask                  unity-yaml
 *.mat                   unity-yaml
 *.meta                  unity-yaml
@@ -40,6 +41,7 @@
 *.scenetemplate         unity-yaml
 *.shadervariants        unity-yaml
 *.spriteatlas           unity-yaml
+*.spriteatlasv2         unity-yaml
 *.terrainlayer          unity-yaml
 *.unity                 unity-yaml
 

--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -1,133 +1,147 @@
 # Define macros
-[attr]lfs           filter=lfs diff=lfs merge=lfs -text
-[attr]unity-yaml    merge=unityyamlmerge text linguist-language=yaml
+[attr]lfs               filter=lfs diff=lfs merge=lfs -text
+[attr]unity-yaml        merge=unityyamlmerge text linguist-language=yaml
 
 # Optionally collapse Unity-generated files on GitHub diffs
-# [attr]unity-yaml    merge=unityyamlmerge text linguist-language=yaml linguist-generated
+# [attr]unity-yaml        merge=unityyamlmerge text linguist-language=yaml linguist-generated
 
 # Unity
-*.asmdef            text linguist-language=json
-*.asmref            text linguist-language=json
-*.cginc             text
-*.compute           text linguist-language=hlsl
-*.cs                text diff=csharp
-*.index             text linguist-language=json
-*.raytrace          text linguist-language=hlsl
-*.shader            text
-*.shadergraph       text linguist-language=json
-*.shadersubgraph    text linguist-language=json
-*.tss               text diff=css linguist-language=css
-*.uss               text diff=css linguist-language=css
-*.uxml              text linguist-language=xml
+*.asmdef                text linguist-language=json
+*.asmref                text linguist-language=json
+*.cginc                 text
+*.compute               text linguist-language=hlsl
+*.cs                    text diff=csharp
+*.index                 text linguist-language=json
+*.raytrace              text linguist-language=hlsl
+*.shader                text
+*.shadergraph           text linguist-language=json
+*.shadersubgraph        text linguist-language=json
+*.tss                   text diff=css linguist-language=css
+*.uss                   text diff=css linguist-language=css
+*.uxml                  text linguist-language=xml
 
 # Unity YAML
-*.anim              unity-yaml
-*.asset             unity-yaml
-*.controller        unity-yaml
-*.mat               unity-yaml
-*.meta              unity-yaml
-*.prefab            unity-yaml
-*.unity             unity-yaml
+*.anim                  unity-yaml
+*.asset                 unity-yaml
+*.brush                 unity-yaml
+*.controller            unity-yaml
+*.flare                 unity-yaml
+*.fontsettings          unity-yaml
+*.giparams              unity-yaml
+*.guiskin               unity-yaml
+*.mask                  unity-yaml
+*.mat                   unity-yaml
+*.meta                  unity-yaml
+*.mixer                 unity-yaml
+*.overrideController    unity-yaml
+*.playable              unity-yaml
+*.prefab                unity-yaml
+*.renderTexture         unity-yaml
+*.scenetemplate         unity-yaml
+*.shadervariants        unity-yaml
+*.spriteatlas           unity-yaml
+*.terrainlayer          unity-yaml
+*.unity                 unity-yaml
 
 # "physic" for 3D but "physics" for 2D
-*.physicMaterial    unity-yaml
-*.physicsMaterial2D unity-yaml
+*.physicMaterial        unity-yaml
+*.physicsMaterial2D     unity-yaml
 
 # Using Git LFS
 # Replace 'binary' with 'lfs' on large files you wish to track with LFS
 
 # Unity LFS
-*.cubemap           binary
-*.unitypackage      binary
+*.cubemap               binary
+*.unitypackage          binary
 
 # 3D models
-*.3dm               binary
-*.3ds               binary
-*.blend             binary
-*.c4d               binary
-*.collada           binary
-*.dae               binary
-*.dxf               binary
-*.FBX               binary
-*.fbx               binary
-*.jas               binary
-*.lws               binary
-*.lxo               binary
-*.ma                binary
-*.max               binary
-*.mb                binary
-*.obj               binary
-*.ply               binary
-*.skp               binary
-*.stl               binary
-*.ztl               binary
+*.3dm                   binary
+*.3ds                   binary
+*.blend                 binary
+*.c4d                   binary
+*.collada               binary
+*.dae                   binary
+*.dxf                   binary
+*.FBX                   binary
+*.fbx                   binary
+*.jas                   binary
+*.lws                   binary
+*.lxo                   binary
+*.ma                    binary
+*.max                   binary
+*.mb                    binary
+*.obj                   binary
+*.ply                   binary
+*.skp                   binary
+*.stl                   binary
+*.ztl                   binary
 
 # Audio
-*.aif               binary
-*.aiff              binary
-*.it                binary
-*.mod               binary
-*.mp3               binary
-*.ogg               binary
-*.s3m               binary
-*.wav               binary
-*.xm                binary
+*.aif                   binary
+*.aiff                  binary
+*.it                    binary
+*.mod                   binary
+*.mp3                   binary
+*.ogg                   binary
+*.s3m                   binary
+*.wav                   binary
+*.xm                    binary
 
 # Video
-*.asf               binary
-*.avi               binary
-*.flv               binary
-*.mov               binary
-*.mp4               binary
-*.mpeg              binary
-*.mpg               binary
-*.ogv               binary
-*.wmv               binary
+*.asf                   binary
+*.avi                   binary
+*.flv                   binary
+*.mov                   binary
+*.mp4                   binary
+*.mpeg                  binary
+*.mpg                   binary
+*.ogv                   binary
+*.wmv                   binary
 
 # Images
-*.bmp               binary
-*.exr               binary
-*.gif               binary
-*.hdr               binary
-*.iff               binary
-*.jpeg              binary
-*.jpg               binary
-*.pict              binary
-*.png               binary
-*.psd               binary
-*.tga               binary
-*.tif               binary
-*.tiff              binary
-*.webp              binary
+*.bmp                   binary
+*.exr                   binary
+*.gif                   binary
+*.hdr                   binary
+*.iff                   binary
+*.jpeg                  binary
+*.jpg                   binary
+*.pict                  binary
+*.png                   binary
+*.psd                   binary
+*.tga                   binary
+*.tif                   binary
+*.tiff                  binary
+*.webp                  binary
 
 # Compressed Archive
-*.7z                binary
-*.bz2               binary
-*.gz                binary
-*.rar               binary
-*.tar               binary
-*.zip               binary
+*.7z                    binary
+*.bz2                   binary
+*.gz                    binary
+*.rar                   binary
+*.tar                   binary
+*.zip                   binary
 
 # Compiled Dynamic Library
-*.dll               binary
-*.pdb               binary
-*.so                binary
+*.dll                   binary
+*.pdb                   binary
+*.so                    binary
 
 # Fonts
-*.otf               binary
-*.ttf               binary
+*.otf                   binary
+*.ttf                   binary
 
 # Executable/Installer
-*.apk               binary
-*.exe               binary
+*.apk                   binary
+*.exe                   binary
 
 # Documents
-*.pdf               binary
+*.pdf                   binary
 
 # ETC
-*.a                 binary
-*.reason            binary
-*.rns               binary
+*.a                     binary
+*.reason                binary
+*.rns                   binary
 
 # Spine export file for Unity
-*.skel.bytes        binary
+*.skel.bytes            binary

--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -3,91 +3,91 @@
 [attr]lfs           filter=lfs diff=lfs merge=lfs -text
 
 # Unity
-*.cginc              text
-*.cs                 text diff=csharp
-*.shader             text
+*.cginc             text
+*.cs                text diff=csharp
+*.shader            text
 
 # Unity YAML
-*.mat                unity-yaml
-*.anim               unity-yaml
-*.unity              unity-yaml
-*.prefab             unity-yaml
-*.asset              unity-yaml
-*.meta               unity-yaml
-*.controller         unity-yaml
+*.mat               unity-yaml
+*.anim              unity-yaml
+*.unity             unity-yaml
+*.prefab            unity-yaml
+*.asset             unity-yaml
+*.meta              unity-yaml
+*.controller        unity-yaml
 
 # "physic" for 3D but "physics" for 2D
-*.physicMaterial2D   unity-yaml
-*.physicMaterial     unity-yaml
-*.physicsMaterial2D  unity-yaml
-*.physicsMaterial    unity-yaml
+*.physicMaterial2D  unity-yaml
+*.physicMaterial    unity-yaml
+*.physicsMaterial2D unity-yaml
+*.physicsMaterial   unity-yaml
 
 # Using Git LFS
 # Replace 'binary' with 'lfs' on large files you wish to track with LFS
 
 # Unity LFS
-*.cubemap            binary
-*.unitypackage       binary
+*.cubemap           binary
+*.unitypackage      binary
 
 # 3D models
-*.3dm                binary
-*.3ds                binary
-*.blend              binary
-*.c4d                binary
-*.collada            binary
-*.dae                binary
-*.dxf                binary
-*.FBX                binary
-*.fbx                binary
-*.jas                binary
-*.lws                binary
-*.lxo                binary
-*.ma                 binary
-*.max                binary
-*.mb                 binary
-*.obj                binary
-*.ply                binary
-*.skp                binary
-*.stl                binary
-*.ztl                binary
+*.3dm               binary
+*.3ds               binary
+*.blend             binary
+*.c4d               binary
+*.collada           binary
+*.dae               binary
+*.dxf               binary
+*.FBX               binary
+*.fbx               binary
+*.jas               binary
+*.lws               binary
+*.lxo               binary
+*.ma                binary
+*.max               binary
+*.mb                binary
+*.obj               binary
+*.ply               binary
+*.skp               binary
+*.stl               binary
+*.ztl               binary
 
 # Audio
-*.aif                binary
-*.aiff               binary
-*.it                 binary
-*.mod                binary
-*.mp3                binary
-*.ogg                binary
-*.s3m                binary
-*.wav                binary
-*.xm                 binary
+*.aif               binary
+*.aiff              binary
+*.it                binary
+*.mod               binary
+*.mp3               binary
+*.ogg               binary
+*.s3m               binary
+*.wav               binary
+*.xm                binary
 
 # Video
-*.asf                binary
-*.avi                binary
-*.flv                binary
-*.mov                binary
-*.mp4                binary
-*.mpeg               binary
-*.mpg                binary
-*.ogv                binary
-*.wmv                binary
+*.asf               binary
+*.avi               binary
+*.flv               binary
+*.mov               binary
+*.mp4               binary
+*.mpeg              binary
+*.mpg               binary
+*.ogv               binary
+*.wmv               binary
 
 # Images
-*.bmp                binary
-*.exr                binary
-*.gif                binary
-*.hdr                binary
-*.iff                binary
-*.jpeg               binary
-*.jpg                binary
-*.pict               binary
-*.png                binary
-*.psd                binary
-*.tga                binary
-*.tif                binary
-*.tiff               binary
-*.webp               binary
+*.bmp               binary
+*.exr               binary
+*.gif               binary
+*.hdr               binary
+*.iff               binary
+*.jpeg              binary
+*.jpg               binary
+*.pict              binary
+*.png               binary
+*.psd               binary
+*.tga               binary
+*.tif               binary
+*.tiff              binary
+*.webp              binary
 
 # Compressed Archive
 *.7z                binary

--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -5,18 +5,22 @@
 # Optionally collapse Unity-generated files on GitHub diffs
 # [attr]unity-yaml        merge=unityyamlmerge text linguist-language=yaml linguist-generated
 
-# Unity
-*.asmdef                text linguist-language=json
-*.asmref                text linguist-language=json
+# Unity files
 *.cginc                 text
 *.compute               text linguist-language=hlsl
 *.cs                    text diff=csharp
-*.index                 text linguist-language=json
-*.inputactions          text linguist-language=json
 *.raytrace              text linguist-language=hlsl
 *.shader                text
+
+# Unity JSON files
+*.asmdef                text linguist-language=json
+*.asmref                text linguist-language=json
+*.index                 text linguist-language=json
+*.inputactions          text linguist-language=json
 *.shadergraph           text linguist-language=json
 *.shadersubgraph        text linguist-language=json
+
+# Unity UI Toolkit files
 *.tss                   text diff=css linguist-language=css
 *.uss                   text diff=css linguist-language=css
 *.uxml                  text linguist-language=xml linguist-detectable

--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -12,6 +12,7 @@
 *.compute               text linguist-language=hlsl
 *.cs                    text diff=csharp
 *.index                 text linguist-language=json
+*.inputactions          text linguist-language=json
 *.raytrace              text linguist-language=hlsl
 *.shader                text
 *.shadergraph           text linguist-language=json

--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -6,9 +6,19 @@
 # [attr]unity-yaml    merge=unityyamlmerge text linguist-language=yaml linguist-generated
 
 # Unity
+*.asmdef            text linguist-language=json
+*.asmref            text linguist-language=json
 *.cginc             text
+*.compute           text linguist-language=hlsl
 *.cs                text diff=csharp
+*.index             text linguist-language=json
+*.raytrace          text linguist-language=hlsl
 *.shader            text
+*.shadergraph       text linguist-language=json
+*.shadersubgraph    text linguist-language=json
+*.tss               text diff=css linguist-language=css
+*.uss               text diff=css linguist-language=css
+*.uxml              text linguist-language=xml
 
 # Unity YAML
 *.anim              unity-yaml

--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -41,6 +41,7 @@
 *.renderTexture         unity-yaml
 *.scenetemplate         unity-yaml
 *.shadervariants        unity-yaml
+*.signal                unity-yaml
 *.spriteatlas           unity-yaml
 *.spriteatlasv2         unity-yaml
 *.terrainlayer          unity-yaml


### PR DESCRIPTION
The Unity file needed some love.

- Combined some largely reused effects in a macro so it's much more concise (macros are only allowed in the root dir of a repo, so I'm not sure if that would be an issue)
- Added new YAML and other file types specific to Unity
- Set linguist-language to some files that have grammar support (HLSL, JSON, CSS) - [linguist reference](https://github.com/github-linguist/linguist/blob/master/lib/linguist/languages.yml)
- Set the language for UXML files as `xml`, which marks it as `data` and so hides it from language stats, so I also made it `linguist-detectable` so it shows. My reasoning is that UXML is more HTML than XML if we look at more than just the syntax.
- Made the "collapse diffs on GitHub" part optional so that users can comment it out to use it
- There might be more Unity extensions to add. I just created everything under Assets/Create in Unity. There's this link to maybe investigate: [Unity docs reference](https://docs.unity3d.com/Manual/BuiltInImporters.html)
- I can also mark some popular paths such as `/Assets/Plugins/**` or `/Assets/TextMesh Pro/**` as `linguist-vendored` if that's fine.

Questions:
- Why are we defaulting to not using LFS? I'm asking because it seems unintuitive to me that LFS is opt-in instead of default.
- I didn't recognize the "Spine export file", so I looked it up and it seems to be a 3rd party package, not a global Unity file. Should I remove it?

I tried to make my commits as atomic as possible so we can pick and choose the changes to keep. Let me know if anything needs to change.