### PR TITLE
Make Git Attributes appear in the language breakdown statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -22,3 +22,5 @@
 # Enable syntax highlighting for files with `.gitattributes` extensions.
 #
 *.gitattributes linguist-language=gitattributes
+*.gitattributes linguist-detectable=true
+*.gitattributes linguist-documentation=false


### PR DESCRIPTION
By making this change, "Git Attributes" will appear as a part of the repo content in the breakdown statistics.

Currently this is 100% Shell.
![image](https://github.com/alexkaratarakis/gitattributes/assets/31558169/324ce128-c316-46e1-ac33-e6571165c8d6)

