### PR TITLE
Add JavaScript .cjs and .mjs extensions

### DIFF
--- a/Drupal.gitattributes
+++ b/Drupal.gitattributes
@@ -25,6 +25,8 @@
 *.inc     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php
 *.install text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2 diff=php
 *.js      text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
+*.mjs     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
+*.cjs     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.json    text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.lock    text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2
 *.map     text eol=lf whitespace=blank-at-eol,-blank-at-eof,-space-before-tab,tab-in-indent,tabwidth=2

--- a/Java.gitattributes
+++ b/Java.gitattributes
@@ -14,6 +14,8 @@
 *.htm           text diff=html
 *.html          text diff=html
 *.js            text
+*.mjs           text
+*.cjs           text
 *.jsp           text
 *.jspf          text
 *.jspx          text

--- a/Servoy.gitattributes
+++ b/Servoy.gitattributes
@@ -10,3 +10,5 @@
 *.sec -text
 *.css text diff=css
 *.js       seol=lf
+*.mjs      seol=lf
+*.cjs      seol=lf

--- a/Web.gitattributes
+++ b/Web.gitattributes
@@ -26,6 +26,8 @@
 *.inc             text
 *.ini             text
 *.js              text
+*.mjs             text
+*.cjs             text
 *.json            text
 *.jsx             text
 *.less            text

--- a/community/Ballerina.gitattributes
+++ b/community/Ballerina.gitattributes
@@ -13,6 +13,8 @@
 *.htm           text diff=html
 *.html          text diff=html
 *.js            text
+*.mjs           text
+*.cjs           text
 *.json          text
 *.properties    text
 *.sh            text eol=lf


### PR DESCRIPTION
Somewhat recently, .mjs and .cjs became additional file extensions for JavaScript runtimes to load and read. This adds those file extensions, whenever a .js pattern is used. That way, there is nothing unexpected and there is uniformity when it comes to git handling JavaScript files.

I know the README says that only one file should be modified per commit, but I think my changes are small enough as to not cause merge conflicts?

Closes #157