### PR TITLE
perf(check.sh): Use POSIX parameter expansion instead of subshell

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -129,7 +129,7 @@ check_cmd() {
 # Show help message
 show_help() {
     cat << EOF
-Usage: $(basename "$0")
+Usage: ${0##*/}
          [--disable-color] [--git-dir <DIR>] [--help]
          [--log-level <LEVEL>]
 


### PR DESCRIPTION
Title. 

```console
$ ./check.sh --help
Usage: check.sh
         [--disable-color] [--git-dir <DIR>] [--help]
         [--log-level <LEVEL>]

.gitattributes checker.

Options:
  --disable-color        Disable color

  --git-dir <DIR>        Git directory
                         Default: .git

  --help                 Show this help message and exit

  --log-level <LEVEL>    Logger level
                         Default: info
                         Values:
                           error    Error level
                           warn     Warning level
                           info     Informational level
                           debug    Debug level 
```