### PR TITLE
Adding LightningData.asset Exception to Unity gitattributes

### DIFF
--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -156,3 +156,6 @@ Assets/Plugins/**       linguist-vendored
 
 # Spine export file for Unity
 *.skel.bytes            lfs
+
+# Exceptions for .asset files such as lightning pre-baking
+LightningData.asset     binary


### PR DESCRIPTION
This PR should add an exception for Lightning Pre-bake data which come as an `*.asset` file but are not YAML serializable. 