### PR TITLE
Fixed spelling mistake in commit ea2378f (LightningData.asset => LightingData.asset)

### DIFF
--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -158,4 +158,4 @@ Assets/Plugins/**       linguist-vendored
 *.skel.bytes            lfs
 
 # Exceptions for .asset files such as lightning pre-baking
-LightningData.asset     binary
+LightingData.asset     binary


### PR DESCRIPTION
Last commit (ea2378f) added an exception for LightningData.asset files, however the files generated by unity are named LightingData.asset