### PR TITLE
Update Unity gitattributes for blender save versions

### DIFF
--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -68,7 +68,7 @@ Assets/Plugins/**       linguist-vendored
 # 3D models
 *.3dm                   lfs
 *.3ds                   lfs
-*.blend                 lfs
+*.blend*                 lfs
 *.c4d                   lfs
 *.collada               lfs
 *.dae                   lfs

--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -68,7 +68,7 @@ Assets/Plugins/**       linguist-vendored
 # 3D models
 *.3dm                   lfs
 *.3ds                   lfs
-*.blend*                 lfs
+*.blend*                lfs
 *.c4d                   lfs
 *.collada               lfs
 *.dae                   lfs


### PR DESCRIPTION
Blender creates multiple copies of the `.blend` file, and by default it also creates a `.blend1` file.