### PR TITLE
Removes problematic wildcard from .blend files

### DIFF
--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -68,7 +68,7 @@ Assets/Plugins/**       linguist-vendored
 # 3D models
 *.3dm                   lfs
 *.3ds                   lfs
-*.blend*                lfs
+*.blend                 lfs
 *.c4d                   lfs
 *.collada               lfs
 *.dae                   lfs


### PR DESCRIPTION
Removes wildcard from .blend files, that caused git to treat .blend.meta as files that are supposed to be placed in LFS, while it should've been treated as a YAML file.