### PR TITLE
Added .tgz Unity packages.

### DIFF
--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -131,6 +131,7 @@ Assets/Plugins/**       linguist-vendored
 *.gz                    lfs
 *.rar                   lfs
 *.tar                   lfs
+*.tgz                   lfs
 *.zip                   lfs
 
 # Compiled Dynamic Library


### PR DESCRIPTION
Hi!

Some Unity packages, including official ones, are distributed in `.tgz` format. Added it to gitattributes.