### PR TITLE
Made all *.env files be handled instead of only `.env`

### DIFF
--- a/Web.gitattributes
+++ b/Web.gitattributes
@@ -106,7 +106,7 @@ TODO              text
 *.conf            text
 *.config          text
 .editorconfig     text
-.env              text
+*.env             text
 .gitattributes    text
 .gitconfig        text
 .htaccess         text


### PR DESCRIPTION
It's quite common to have
1. template.env
2. example.env
3. .dev.env
4. .prod.env
5. etc