### PR TITLE
Add handling for windows .bat files

### DIFF
--- a/Java.gitattributes
+++ b/Java.gitattributes
@@ -38,3 +38,6 @@
 # Common build-tool wrapper scripts ('.cmd' versions are handled by 'Common.gitattributes')
 mvnw            text eol=lf
 gradlew         text eol=lf
+
+# These are explicitly windows files and should use crlf
+*.bat           text eol=crlf


### PR DESCRIPTION
This is based on this line in the Gradle/gradle repo: https://github.com/gradle/gradle/blob/master/.gitattributes#L9