### PR TITLE
Put general usage info in README together

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,19 @@ templates for `.gitattributes`.
 `Common.gitattributes` contains general exclusions that may apply to any project.
 Consider including them if they are applicable to your project.
 
-You can use [this](https://richienb.github.io/gitattributes-generator) or [this](https://gitattributes.com/) handy dandy generator to generate your gitattributes files on the fly based on files inside of this repository.
+## Usage
+
+For more information on gitattributes: [gitattributes(5)][g5] and for
+Github-specific grammar: [Linguist docs][gh]
+
+You can use [this](https://richienb.github.io/gitattributes-generator) or
+[this](https://gitattributes.com/) handy dandy generator to generate your
+gitattributes files on the fly based on files inside of this repository.
 
 ## CI step
 
-To check if all files have a corresponding rule in .gitattributes, this script can be used:
+To check if all files have a corresponding rule in .gitattributes, this script
+can be used:
 
 ```sh
 missing_attributes=$(git ls-files | git check-attr -a --stdin | grep 'text: auto' || printf '\n')
@@ -31,8 +39,6 @@ Please contribute by [forking][fk] and sending a [pull request][pr].
 
 Also **please** only modify **one file** per commit. This'll
 make merging easier for everyone.
-
-For more information on gitattributes: [gitattributes(5)][g5] and for Github-specific grammar: [Linguist docs][gh]
 
 [gt]: https://github.com/github/gitignore
 [fk]: http://help.github.com/forking/


### PR DESCRIPTION
I noticed that the general usage information was spread across two different areas of the README.  So this PR is intended to bring that information together in a single section, to make it easier for new folks that find this repo.

I also cleaned up a few line lengths that gave warnings for Markdownlint.

Fixes #203 