### PR TITLE
Fix `*.pdf` attribute in Delphi gitattributes

### DIFF
--- a/Delphi.gitattributes
+++ b/Delphi.gitattributes
@@ -46,7 +46,7 @@
 *.odt  text
 
 # Portable Document Format
-*.pdf  text
+*.pdf  binary
 
 # PostScript
 *.ps   text


### PR DESCRIPTION
Closes #181

Doesn't make sense that the PDF format should be treated as text, must of been a typo or something. This fixes that.
Edit: Removed the reference to 204