### PR TITLE
Remove use of `astextplain`

### DIFF
--- a/Common.gitattributes
+++ b/Common.gitattributes
@@ -9,16 +9,16 @@
 
 # Documents
 *.bibtex   text diff=bibtex
-*.doc      diff=astextplain
-*.DOC      diff=astextplain
-*.docx     diff=astextplain
-*.DOCX     diff=astextplain
-*.dot      diff=astextplain
-*.DOT      diff=astextplain
-*.pdf      diff=astextplain
-*.PDF      diff=astextplain
-*.rtf      diff=astextplain
-*.RTF      diff=astextplain
+*.doc      binary
+*.DOC      binary
+*.docx     binary
+*.DOCX     binary
+*.dot      binary
+*.DOT      binary
+*.pdf      binary
+*.PDF      binary
+*.rtf      text
+*.RTF      text
 *.md       text diff=markdown
 *.mdx      text diff=markdown
 *.tex      text diff=tex

--- a/Common.gitattributes
+++ b/Common.gitattributes
@@ -30,7 +30,7 @@
 *.tsv      text
 *.txt      text
 *.sql      text
-*.epub     diff=astextplain
+*.epub     diff=binary
 
 # Graphics
 *.png      binary


### PR DESCRIPTION
astexplain is a [script used in `git-for-windows`](https://github.com/git-for-windows/build-extra/blob/main/git-extra/astextplain).

Naturally, this means that when the `astextplain` attribute is used, it will always yield to different results when not everyone is using `git-for-windows`. Furthermore, adding attributes that converts Microsoft documents, PDFs, etc. to text (for diff views) is non-default. And unexpected behavior, at least in my opinion.

As a side-effect, the attributes for `*.rtf` are now consistent across `Common.gitattributes` and `Delphi.gitattributes`.

Closes #220