### PR TITLE
Unity: Blender backup files and linguist attributes

### DIFF
--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -69,6 +69,7 @@ Assets/Plugins/**       linguist-vendored
 *.3dm                   lfs
 *.3ds                   lfs
 *.blend                 lfs
+*.blend1                lfs
 *.c4d                   lfs
 *.collada               lfs
 *.dae                   lfs

--- a/Unity.gitattributes
+++ b/Unity.gitattributes
@@ -3,7 +3,7 @@
 [attr]unity-json        eol=lf linguist-language=json
 [attr]unity-yaml        merge=unityyamlmerge eol=lf linguist-language=yaml
 
-# Optionally collapse Unity-generated files on GitHub diffs
+# Optionally collapse Unity YAML files on GitHub diffs
 # [attr]unity-yaml        merge=unityyamlmerge text linguist-language=yaml linguist-generated
 
 # Unity source files
@@ -27,7 +27,7 @@
 *.uss                   text diff=css linguist-language=css
 *.uxml                  text linguist-language=xml linguist-detectable
 
-# Unity YAML
+# Unity YAML files
 *.anim                  unity-yaml
 *.asset                 unity-yaml
 *.brush                 unity-yaml
@@ -58,8 +58,9 @@
 *.physicMaterial        unity-yaml
 *.physicsMaterial2D     unity-yaml
 
-# Exclude third-party plugins from GitHub stats
-Assets/Plugins/**       linguist-vendored
+# Exclude from GitHub stats and diffs: third-party plugins, packages lock file
+Assets/Plugins/**           linguist-generated
+Packages/packages-lock.json linguist-generated
 
 # Unity LFS
 *.cubemap               lfs


### PR DESCRIPTION
## Change 1 - Historical context

1. `.blend1` files were included with a wildcard in #228
2. The wildcard was removed to fix `.blend.meta` files in #229
3. On another note, `.blend1` was added to the **gitignore** in github/gitignore#4589

Merging 1 and 2, I added a new rule for `.blend1` files specifically. This also prevents people using an old version of the `gitignore` template from using different rules for `.blend1` and `.blend`.

## Change 2

Unity's package manager keeps a `packages-lock.json` lock file that can be automatically hidden in diffs and excluded from repo language stats on GitHub. I also changed the previous `Assets/Plugins/**` rule to do the same (it was only excluded from stats).