### PR TITLE
Added more official extensions for C++

### DIFF
--- a/C++.gitattributes
+++ b/C++.gitattributes
@@ -1,14 +1,25 @@
-# Sources
+# C Source files
 *.c     text diff=cpp
-*.cc    text diff=cpp
-*.cxx   text diff=cpp
-*.cpp   text diff=cpp
-*.cpi   text diff=cpp
-*.c++   text diff=cpp
-*.hpp   text diff=cpp
 *.h     text diff=cpp
-*.h++   text diff=cpp
+
+# C++ Source files (all recognized extensions)
+*.C     text diff=cpp
+*.cc    text diff=cpp
+*.cpp   text diff=cpp
+*.CPP   text diff=cpp
+*.c++   text diff=cpp
+*.cxx   text diff=cpp
+*.cpi   text diff=cpp
+
+# C++ Header files
+*.H     text diff=cpp
 *.hh    text diff=cpp
+*.hpp   text diff=cpp
+*.h++   text diff=cpp
+*.hxx   text diff=cpp
+
+# C++ Preprocessed files
+*.ii    text diff=cpp
 
 # Compiled Object files
 *.slo   binary


### PR DESCRIPTION
This PR adds support for more C++ file extensions:
- .C
- .CPP
- .H
- .hxx
- .ii

They may not be commonly used, but they are widely supported by editors and LSPs. 